### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 app.py"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # WishPyStock
 
-# Descargar el proyecto
+## Repl.it 
+
+[![Run on Repl.it](https://repl.it/badge/github/joaquinbf/yougrabr)](https://repl.it/github/joaquinbf/yougrabr)
+
+## Descargar el proyecto
 
 Este proyecto se puede descargar haciendo clic en el botón `Clone or Download` y luego `Download ZIP`. Previo a trabajar, descomprimir el archivo `.zip` descargado. 
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).